### PR TITLE
feat: export chalk for one-off use

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,14 @@ module.exports = function webpackLog(options) {
   return log;
 };
 
+// NOTE: this is exported so that consumers of webpack-log can use the same
+//       version of chalk to decorate log messages without incurring additional
+//       dependency overhead. This is an atypical practice, but chalk version
+//       segmentation is a common issue.
+module.exports.chalk = chalk;
+
 /**
- * @note: This is an undocumented function solely for the purpose of tests.
+ * @NOTE: This is an undocumented function solely for the purpose of tests.
  *        Do not use this method in production code. Using in production code
  *        may result in strange behavior.
  */


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a new **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No need

### Motivation / Use-Case

chalk is exported so that consumers of webpack-log can use the same
version of chalk to decorate log messages without incurring additional
dependency overhead. This is an atypical practice, but chalk version
segmentation is a common issue.

### Breaking Changes

None

### Additional Info
