### PR TITLE
refactor(package): replace `chalk` with `ansi-colors` (`dependencies`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,15 @@
 'use strict';
 
-const chalk = require('chalk');
+const colors = require('ansi-colors');
 const loglevel = require('loglevelnext'); //eslint-disable-line
-const logSymbols = require('log-symbols');
 const uuid = require('uuid/v4');
 
 const symbols = {
-  trace: chalk.grey('₸'),
-  debug: chalk.cyan('➤'),
-  info: logSymbols.info,
-  warn: logSymbols.warning,
-  error: logSymbols.error
+  trace: colors.grey('₸'),
+  debug: colors.cyan('➤'),
+  info: colors.blue(colors.symbols.info),
+  warn: colors.yellow(colors.symbols.warning),
+  error: colors.red(colors.symbols.cross)
 };
 
 const defaults = {
@@ -21,7 +20,7 @@ const defaults = {
 
 const prefix = {
   level: opts => symbols[opts.level],
-  template: `{{level}} ${chalk.gray('｢{{name}}｣')}: `
+  template: `{{level}} ${colors.gray('｢{{name}}｣')}: `
 };
 
 module.exports = function webpackLog(options) {
@@ -59,10 +58,9 @@ module.exports = function webpackLog(options) {
 };
 
 // NOTE: this is exported so that consumers of webpack-log can use the same
-//       version of chalk to decorate log messages without incurring additional
-//       dependency overhead. This is an atypical practice, but chalk version
-//       segmentation is a common issue.
-module.exports.chalk = chalk;
+//       version of ansi-colors to decorate log messages without incurring additional
+//       dependency overhead
+module.exports.colors = colors;
 
 /**
  * @NOTE: This is an undocumented function solely for the purpose of tests.

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "index.js"
   ],
   "dependencies": {
-    "chalk": "^2.1.0",
-    "log-symbols": "^2.1.0",
+    "ansi-colors": "^3.0.0",
     "loglevelnext": "^1.0.1",
     "uuid": "^3.1.0"
   },


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a new **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

This PR replaces chalk and log-symbols with [ansi-colors](https://github.com/doowb/ansi-colors).
`ansi-colors` doesn't have any dependencies and includes the symbols that `webpack-contrib` already uses.

`ansi-colors` also has notable performance improves when loading and executing compared to `chalk`. See [the benchmarks](https://github.com/doowb/ansi-colors#performance) for more information.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

All the tests pass and it doesn't look like there are any breaking changes.

### Additional Info
